### PR TITLE
[ISSUE-27] Prisma client generation 오류 해결

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -7,6 +7,7 @@
 generator client {
   provider = "prisma-client-js"
   output   = "../src/generated/prisma"
+  binaryTargets = ["native", "rhel-openssl-1.0.x"]
 }
 
 generator zod {


### PR DESCRIPTION
## 작업한 내용

Amplify 배포 환경에서 prisma client가 제대로 초기화되지 않던 문제점을 해결했습니다.