### PR TITLE
[ISSUE-27] AuthOption secret 추가

### DIFF
--- a/src/app/api/auth/[...nextauth]/authOptions.ts
+++ b/src/app/api/auth/[...nextauth]/authOptions.ts
@@ -9,6 +9,7 @@ export const authOptions: AuthOptions = {
       clientSecret: process.env.KAKAO_CLIENT_SECRET!,
     }),
   ],
+  secret: process.env.NEXTAUTH_SECRET,
   session: {
     strategy: 'jwt',
   },


### PR DESCRIPTION
## 작업한 내용

프로덕션의 next-auth authOption에 시크릿이 없어 발생하는 문제점을 해결했습니다.
환경 변수에 NEXTAUTH_SECRET을 추가했지만 안 돼서 일단 추가했습니다.